### PR TITLE
Fix: reordered priority of subcommands and prevented leader from leaving

### DIFF
--- a/commands/group.js
+++ b/commands/group.js
@@ -123,20 +123,6 @@ subcommands.add({
 });
 
 subcommands.add({
-  name: 'leave',
-  command: state => (args, player) => {
-    if (!player.party) {
-      return say(player, "You're not in a group.");
-    }
-
-    const party = player.party;
-    player.party.delete(player);
-    say(party, `<b><green>${player.name} left the group.</green></b>`);
-    say(player, '<b><green>You leave the group.</green></b>');
-  }
-});
-
-subcommands.add({
   name: 'list',
   command: state => (args, player) => {
     if (!player.party) {
@@ -151,6 +137,24 @@ subcommands.add({
       }
       say(player, `<b><green>${tag} ${member.name}</green></b>`);
     }
+  }
+});
+
+subcommands.add({
+  name: 'leave',
+  command: state => (args, player) => {
+    if (!player.party) {
+      return say(player, "You're not in a group.");
+    }
+
+    if (player === player.party.leader) {
+      return say(player, "You have to disband if you want to leave the group.");
+    }
+
+    const party = player.party;
+    player.party.delete(player);
+    say(party, `<b><green>${player.name} left the group.</green></b>`);
+    say(player, '<b><green>You leave the group.</green></b>');
   }
 });
 


### PR DESCRIPTION
Currently, if you do a `GROUP L`, that translates as a `GROUP LEAVE` action.  That might be unsettling to a player who wanted to do a `GROUP LIST`.  The solution was to reorder the subcommands so that `LIST` was added first.

The second issue was, currently, a leader can leave the group without disbanding it.  I think this was a bug, since no one is promoted to leader when this happens, and no one can invite others or promote themselves to leader.  Everyone instead has to leave the group and start over with a new group with a new leader.  Solution then is to prevent the leader from leaving the group.  They are told to use `DISBAND` if they want to leave the group.